### PR TITLE
fix double counting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13641,20 +13641,28 @@ const { Octokit } = __nccwpck_require__(1231);
 
 async function run () {
   const octokit = new Octokit;
-  const pull_number = github.context.payload["pull_request"]["number"]
-  console.log(`For pull request ${pull_number}`);
-
-  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const pull_number = github.context.payload.pull_request.number
+  const owner = github.context.payload.repository.owner.login
+  const sender = github.context.payload.sender.login
+  const repo = github.context.payload.repository.name
 
   let { data } = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
     owner,
     repo,
     pull_number
   })
-  const commentCount = data.filter((d) => d["state"] === "COMMENTED").length
-  const approvedCount = data.filter((d) => d["state"] === "APPROVED").length
-  const rejectedCount = data.filter((d) => d["state"] === "REJECTED").length
-  console.log(`There ${commentCount} comments, ${approvedCount} approvals, and ${rejectedCount} rejections.`)
+
+  const approvedCount = data
+    .flatMap((review, i, {length}) => {
+      if (length - 1 !== i) {
+        return [{state: review.state, user: review.user.login }]
+      } else {
+        return []
+      }
+    })
+    .filter(r => r.state == 'APPROVED' && r.user != sender)
+    .length
+  console.log(`There are ${approvedCount} approvals.`)
 
   let { data: issue } = await octokit.request('GET /repos/{owner}/{repo}/issues/{pull_number}', {
     owner,


### PR DESCRIPTION
The /reviews endpoint returns a history of reviews, as such we need to just grab the most recent ones to build up a present state of reviews.