### PR TITLE
Update readme with minimal workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ approval.
 
 
 Sample config, place in `.github/workflows/plusone.yml`
-```
+```yaml
 name: Plus one
 
 on:
@@ -16,11 +16,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'npm'
       - uses: planningcenter/plus-one-action@v1.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After using this action in another repo, I found that there were a few parts of the workflow example in the readme that could be trimmed down.

1. actions/checkout doesn't appear to be necessary since the action is exclusively concerned with data from GitHub API calls
2. actions/setup-node isn't necessary since this is packaged up with ncc now and ubuntu-latest comes with Node 16 installed already