### PR TITLE
chore: Use update-action-tags action

### DIFF
--- a/.github/workflows/update-action-tags.yml
+++ b/.github/workflows/update-action-tags.yml
@@ -1,0 +1,15 @@
+name: Update GitHub Action Tags
+
+on:
+  push:
+    tags:
+      - 'v([0-9]+)\.([0-9]+)\.([0-9]+)'
+
+jobs:
+  update-action-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update Semver Tags
+        uses: tchupp/actions-update-semver-tags@v1


### PR DESCRIPTION
### GH Action Tags
The convention in GitHub Actions is to have not only full semver tags (e.g. `v1.2.3`) but also major.minor (`v1.2`) and major (`v1`) tags.  And those last two should point to the most recent release that they describe.

For instance, if the latest release in the repo is `v1.2.3`, that could be referenced by the full version or `v1.2` or `v1`.  This lets workflows that use these actions opt into whatever level of version updates they're comfortable with.  

A workflow using `@v1` will get the latest `v1.x.x` (i.e. all minor and patch updates) automatically on each run.

### New Workflow
This repo is mostly in a good place, but it still requires some manual work.

This workflow does the work of creating and updating major and major.minor versions as we create new full version tags.