### PR TITLE
fix: exclude COMMENTED PRs from affecting label status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 name: "Plus one"
+description: A GitHub action which labels a PR with +1 or +2 according to reviews
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -13639,25 +13639,25 @@ const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
 const { Octokit } = __nccwpck_require__(1231);
 
-async function run () {
+async function run() {
   const octokit = new Octokit;
   const pull_number = github.context.payload.pull_request.number
   const owner = github.context.payload.repository.owner.login
   const repo = github.context.payload.repository.name
-
 
   const prReviews = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
     owner,
     repo,
     pull_number
   })
-
   console.log(`prReviews: ${JSON.stringify(prReviews, undefined, 2)}`)
+
   let reviews = []
-  prReviews.data.reverse().forEach(review => {
+  let filteredPrReviews = prReviews.data.reverse().filter(review => review.state !== "COMMENTED");
+  filteredPrReviews.forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
-      reviews.push({reviewer: reviewer, state: review.state})
+      reviews.push({ reviewer: reviewer, state: review.state })
     }
   });
   console.log(`reviews: ${JSON.stringify(reviews, undefined, 2)}`)
@@ -13669,7 +13669,7 @@ async function run () {
     owner,
     repo,
     pull_number,
-  }) 
+  })
 
   const labels = issue["labels"].map(l => l["name"])
   let filteredLabels = labels.filter((l) => !["+1", "+2"].includes(l))
@@ -13694,6 +13694,7 @@ try {
 } catch (error) {
   core.setFailed(error.message);
 }
+
 })();
 
 module.exports = __webpack_exports__;

--- a/src/main.js
+++ b/src/main.js
@@ -2,25 +2,25 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const { Octokit } = require("@octokit/action");
 
-async function run () {
+async function run() {
   const octokit = new Octokit;
   const pull_number = github.context.payload.pull_request.number
   const owner = github.context.payload.repository.owner.login
   const repo = github.context.payload.repository.name
-
 
   const prReviews = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
     owner,
     repo,
     pull_number
   })
-
   console.log(`prReviews: ${JSON.stringify(prReviews, undefined, 2)}`)
+
   let reviews = []
-  prReviews.data.reverse().forEach(review => {
+  let filteredPrReviews = prReviews.data.reverse().filter(review => review.state !== "COMMENTED");
+  filteredPrReviews.forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
-      reviews.push({reviewer: reviewer, state: review.state})
+      reviews.push({ reviewer: reviewer, state: review.state })
     }
   });
   console.log(`reviews: ${JSON.stringify(reviews, undefined, 2)}`)
@@ -32,7 +32,7 @@ async function run () {
     owner,
     repo,
     pull_number,
-  }) 
+  })
 
   const labels = issue["labels"].map(l => l["name"])
   let filteredLabels = labels.filter((l) => !["+1", "+2"].includes(l))


### PR DESCRIPTION
There's a flaw in this GitHub action where it removes the `+2` or `+1` labels from pull requests that have an `APPROVED` status. This happens because comments are counted as PR reviews, and the action only considers the most recent review by each reviewer. This means if a reviewer approves a pull request but later comments on it, their latest "review" is now just a comment, and the approval is ignored.

Review states for pull requests include:

-  `APPROVED`: The pull request can merge.
-  `CHANGES_REQUESTED`: Prevents merging.
-  `COMMENTED`: Just informational.
-  `DISMISSED`: Negates an earlier review.
-  `PENDING`: Review is incomplete.

To address this, we should ignore reviews that are solely comments. Our focus is on the most recent review. A pull request should only lose its `+1` or `+2` status if a subsequent review either requests changes, dismisses the earlier approval, or is still pending. Comments alone should not strip away an `APPROVED` status.