### PR TITLE
fix: address issue where +1 / +2 label prematurely gets removed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zhubert
+* @zhubert @wassimk

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Sample config, place in `.github/workflows/plusone.yml`
 name: Plus one
 
 on:
+  pull_request:
+    types: [review_request_removed, review_requested]
   pull_request_review:
-    types: [submitted, dismissed]
+    types: [dismissed, submitted]
 
 jobs:
   lint:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 name: "Plus one"
+description: A GitHub action which labels a PR with +1 or +2 according to reviews
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -13669,7 +13669,7 @@ async function run() {
 
   // Gather most recent review from each reviewer
   // Exclude reviewer if they are in the requested reviewers list
-  filteredPrReviews.forEach(review => {
+  filteredPrReviews.reverse().forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
       if (!requestedReviewers.includes(reviewer)) {

--- a/src/main.js
+++ b/src/main.js
@@ -8,15 +8,15 @@ async function run() {
   const owner = github.context.payload.repository.owner.login
   const repo = github.context.payload.repository.name
 
+  // Gather requested reviewers
   let requestedReviewers = []
   const reviewRequests = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers', {
     owner,
     repo,
     pull_number
   })
-  console.log(`reviewRequests: ${JSON.stringify(reviewRequests, undefined, 2)}`)
 
-  reviewRequests.data.users.forEach(u => requestedReviewers.push(u.login))
+  reviewRequests.data.users.forEach(rr => requestedReviewers.push(rr.login))
   console.log(`requestedReviewers: ${JSON.stringify(requestedReviewers, undefined, 2)}`)
 
   const prReviews = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
@@ -24,12 +24,14 @@ async function run() {
     repo,
     pull_number
   })
-  console.log(`prReviews: ${JSON.stringify(prReviews.data.reverse(), undefined, 2)}`)
 
+  // Gather non-COMMENT PR reviews
   let reviews = []
   let filteredPrReviews = prReviews.data.filter(review => review.state !== "COMMENTED");
   console.log(`filteredPrReviews: ${JSON.stringify(filteredPrReviews, undefined, 2)}`)
 
+  // Gather most recent review from each reviewer
+  // Exclude reviewer if they are in the requested reviewers list
   filteredPrReviews.forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
@@ -41,9 +43,11 @@ async function run() {
 
   console.log(`reviews: ${JSON.stringify(reviews, undefined, 2)}`)
 
+  // Count PR approvals
   const approvedCount = reviews.filter(r => r.state === "APPROVED").length
   console.log(`There are ${approvedCount} approvals.`)
 
+  // Get the current labels, excluding the +1 and +2 labels
   let { data: issue } = await octokit.request('GET /repos/{owner}/{repo}/issues/{pull_number}', {
     owner,
     repo,
@@ -54,6 +58,7 @@ async function run() {
   let filteredLabels = labels.filter((l) => !["+1", "+2"].includes(l))
   console.log(`Filtered labels: ${JSON.stringify(filteredLabels, undefined, 2)}`)
 
+  // Add the new +1 or +2 label, if applicable
   if (approvedCount >= 2) {
     filteredLabels.push("+2")
   } else if (approvedCount == 1) {
@@ -61,6 +66,7 @@ async function run() {
   }
   console.log(`We are setting these labels ${JSON.stringify(filteredLabels, undefined, 2)}`)
 
+  // Set the labels
   await octokit.request('PUT /repos/{owner}/{repo}/issues/{issue_number}/labels', {
     owner,
     repo,
@@ -68,6 +74,7 @@ async function run() {
     labels: filteredLabels,
   })
 }
+
 try {
   run()
 } catch (error) {

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ async function run() {
 
   // Gather most recent review from each reviewer
   // Exclude reviewer if they are in the requested reviewers list
-  filteredPrReviews.forEach(review => {
+  filteredPrReviews.reverse().forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
       if (!requestedReviewers.includes(reviewer)) {

--- a/src/main.js
+++ b/src/main.js
@@ -2,25 +2,25 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const { Octokit } = require("@octokit/action");
 
-async function run () {
+async function run() {
   const octokit = new Octokit;
   const pull_number = github.context.payload.pull_request.number
   const owner = github.context.payload.repository.owner.login
   const repo = github.context.payload.repository.name
-
 
   const prReviews = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
     owner,
     repo,
     pull_number
   })
-
   console.log(`prReviews: ${JSON.stringify(prReviews, undefined, 2)}`)
+
   let reviews = []
-  prReviews.data.reverse().forEach(review => {
+  let filteredPrReviews = prReviews.data.reverse().filter(review => review.state !== "COMMENTED");
+  filteredPrReviews.forEach(review => {
     const reviewer = review.user.login
     if (!reviews.find(r => r.reviewer === reviewer)) {
-      reviews.push({reviewer: reviewer, state: review.state})
+      reviews.push({ reviewer: reviewer, state: review.state })
     }
   });
   console.log(`reviews: ${JSON.stringify(reviews, undefined, 2)}`)
@@ -32,7 +32,7 @@ async function run () {
     owner,
     repo,
     pull_number,
-  }) 
+  })
 
   const labels = issue["labels"].map(l => l["name"])
   let filteredLabels = labels.filter((l) => !["+1", "+2"].includes(l))


### PR DESCRIPTION
There's a flaw in this GitHub action: It removes the `+2` or `+1` labels from pull requests that have an `APPROVED` status. This happens because comments are counted as PR reviews, and the action only considers the most recent review by each reviewer. If a reviewer approves a pull request but later comments, their latest "review" is now just a comment, and the approval is ignored.

Review status for pull requests include:

-  `APPROVED`: The pull request can merge.
-  `CHANGES_REQUESTED`: Prevents merging.
-  `COMMENTED`: Just informational.
-  `DISMISSED`: Negates an earlier review.
-  `PENDING`: Review is incomplete.

To address this, we should ignore reviews that are solely comments. Now a pull request should only lose its `+1` or `+2` status if a review requests changes, dismisses an earlier approval, or is pending a re-review request. Comments alone should not strip away an `APPROVED` status.