### PR TITLE
fix: auto-tagging action to trigger on releases too

### DIFF
--- a/.github/workflows/update-action-tags.yml
+++ b/.github/workflows/update-action-tags.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v([0-9]+)\.([0-9]+)\.([0-9]+)'
+  release:
+    types:
+      - published
+      - edited
 
 jobs:
   update-action-tags:


### PR DESCRIPTION
I just made a new release and noticed the update-action-tags GitHub
action did not fire. I expected it to fire when the release created a
new tag, but it did not. We can specify that it should fire on releases, too.

Refs:

https://github.com/planningcenter/plus-one-action/pull/18
