### PR TITLE
chore(ncc): update to v2

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   ncc-build:
-    uses: planningcenter/balto-utils/.github/workflows/ncc.yml@v1
+    uses: planningcenter/balto-utils/.github/workflows/ncc.yml@v2


### PR DESCRIPTION
It looks like we are running into permission errors with the v1 of ncc.yml. Let's see if bumping it to a more recent version helps.