### PR TITLE
docs: add permissions recommendation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ on:
     types: [review_request_removed, review_requested]
   pull_request_review:
     types: [dismissed, submitted]
+permissions:
+    issues: read
+    pull-requests: write
 
 jobs:
   lint:


### PR DESCRIPTION
Without these permissions defined in the action YAML file, the default permissions in our `GITHUB_TOKEN` work just fine for human-opened PRs. But Dependabot-owned PRs are special and don't work the same way. Explicitly defining the permissions solves errors with Dependabot-owned PR actions.

I'm not specifically calling out Dependabot in the README. Explicitly defining the permissions this action expects stands on its own. Preventing the Dependabot permission issue is a side effect.